### PR TITLE
feat: accept Colota's Overland batch sending

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,14 +3,21 @@ API_KEY=your-secret-key
 # FORWARD_TIMEOUT_MS=30000  # timeout per target in ms (default: 30000)
 
 # Incoming endpoints:
-#   POST /locations      — Colota native format
+#   POST /locations      — Colota native format (single point)
 #   POST /owntracks      — OwnTracks HTTP format (configure OwnTracks app to point here)
+#   POST /overland       — Overland batch format (Colota "Overland" template / batch mode)
 #   GET  /health         — health check
 
 # Targets are forwarded to in parallel.
-# TARGET_n_TYPE: "owntracks" | "geopulse" | "traccar" | "colota" | "raw" (default: raw)
+# TARGET_n_TYPE: "owntracks" | "geopulse" | "traccar" | "colota" | "overland" | "raw" (default: raw)
 # TARGET_n_TID:  tracker ID for owntracks type (default: CL), device ID for traccar type (default: colota)
 # TARGET_n_FILTER_TID: only forward to this target when the payload tid matches this value
+
+# Batch handling (POST /overland): "overland" targets get the whole batch in one request;
+# every other type is split into one request per point.
+# TARGET_n_BATCH_MODE: "split" (default) | "latest" (newest point only — good for Home Assistant)
+# SPLIT_CONCURRENCY / SPLIT_DELAY_MS: global split pacing (default 1 / 0);
+#   override per target with TARGET_n_SPLIT_CONCURRENCY / TARGET_n_SPLIT_DELAY_MS
 
 # Home Assistant — OwnTracks HTTP integration webhook
 # Get this URL from: Settings → Devices & Services → OwnTracks → Configure
@@ -21,10 +28,12 @@ TARGET_1_TYPE=owntracks
 # TARGET_1_DEVICE=phone # optional, default: phone
 # TARGET_1_AUTH= (not needed — HA webhooks are unauthenticated)
 
-# Dawarich
-TARGET_2_URL=http://dawarich:3000/api/v1/points
+# Dawarich (split — one OwnTracks point per request)
+TARGET_2_URL=http://dawarich:3000/api/v1/owntracks/points?api_key=your-key
 TARGET_2_TYPE=owntracks
-TARGET_2_AUTH=Bearer your-dawarich-api-key
+# Or ingest whole batches in one request via Dawarich's native Overland endpoint:
+#   TARGET_2_URL=http://dawarich:3000/api/v1/overland/batches?api_key=your-key
+#   TARGET_2_TYPE=overland
 
 # Colota
 TARGET_3_URL=http://colota:3000/api/location

--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ Receives location updates from the [Colota](https://colota.app) app or any OwnTr
 
 ## Endpoints
 
-| Method | Path         | Auth | Description                                                                     |
-| ------ | ------------ | ---- | ------------------------------------------------------------------------------- |
-| `POST` | `/locations` | yes  | Colota native payload — fans out to all matching targets                        |
-| `POST` | `/owntracks` | yes  | OwnTracks HTTP payload — only `_type: "location"` is forwarded, others drop     |
-| `HEAD` | `/locations` | no   | Connectivity ping — used by the Colota app to verify the URL is reachable       |
-| `GET`  | `/health`    | no   | Health check for Docker / orchestrators — returns `{ status, uptime, targets }` |
+| Method | Path | Auth | Description |
+| --- | --- | --- | --- |
+| `POST` | `/locations` | yes | Colota native payload — fans out to all matching targets |
+| `POST` | `/owntracks` | yes | OwnTracks HTTP payload — only `_type: "location"` is forwarded, others drop |
+| `POST` | `/overland` | yes | Colota batch payload (Overland format) - forwarded whole to `overland` targets, split to single points for the rest |
+| `HEAD` | `/locations` | no | Connectivity ping — used by the Colota app to verify the URL is reachable |
+| `GET` | `/health` | no | Health check for Docker / orchestrators — returns `{ status, uptime, targets }` |
 
 ## Setup
 
@@ -62,7 +63,8 @@ docker compose up -d
 
 **4. Point your app at the forwarder**
 
-- **Colota:** use the **Custom** API scheme and set the endpoint to `https://your-server/locations`
+- **Colota (single point):** use the **Custom** API scheme and set the endpoint to `https://your-server/locations`
+- **Colota (batch mode):** pick the **Overland** template (or **Dawarich** + Batch chip) and set the endpoint to `https://your-server/overland?api_key=your-key`
 - **OwnTracks (Android/iOS):** set mode to HTTP and the URL to `https://your-server/owntracks?api_key=your-key`. Only `_type: "location"` payloads are forwarded — region transitions, waypoints, and other event types are dropped.
 
 Authentication is accepted via `x-api-key` header, `?api_key=` query param, or `Authorization: Bearer` header.
@@ -81,6 +83,8 @@ TARGET_1_TYPE=colota
 ```
 
 The payload is forwarded unchanged (no OwnTracks conversion). The HA entity is named from the payload's `tid` field — e.g. `tid: "iphone15"` becomes `device_tracker.iphone15`.
+
+If the Colota app uses batch mode (Overland template), add `TARGET_n_BATCH_MODE=latest` so HA receives only the newest fix per upload instead of a replay of the whole batch — HA tracks the current position, not history. See [Batch handling](#batch-handling).
 
 **Alternative — built-in OwnTracks webhook:**
 
@@ -150,7 +154,40 @@ TARGET_6_TYPE=owntracks
 | --- | --- | --- |
 | `owntracks` | Home Assistant (built-in OwnTracks integration), Dawarich, Reitti, OwnTracks Recorder | Converts to OwnTracks format, adds `X-Limit-U` / `X-Limit-D` headers |
 | `traccar` | Traccar | GET (OsmAnd protocol) by default; set `METHOD=POST` for the Traccar JSON API |
+| `overland` | Dawarich (native batch endpoint), any Overland-compatible server | Forwards the **whole** Overland batch unchanged. Point the URL at the destination's batch endpoint (Dawarich: `/api/v1/overland/batches` |
 | `geopulse` / `colota` / `raw` | Home Assistant ([Colota integration](https://github.com/dietrichmax/colota-home-assistant)), GeoPulse, Colota-native services, custom endpoints | Passes the Colota payload through unchanged — names exist for documentation only |
+
+## Batch handling
+
+When the Colota app uses the **Overland** template (or **Dawarich** + Batch mode), it uploads multiple points in one request to `/overland`. The forwarder handles each target according to its type and `BATCH_MODE`:
+
+- **`overland` targets** receive the batch **whole** — one HTTP request per upload, regardless of how many points it contains. This is the efficient path; use it whenever the destination understands the Overland batch format (Dawarich does natively).
+- **`TARGET_n_BATCH_MODE=latest`** forwards only the **newest point** of the batch as a single request. Use it for live-state sinks like Home Assistant that track the _current_ position rather than history — it avoids replaying a backlog (which would spam zone automations and bloat history with points stamped at ingestion time).
+- **Otherwise the batch is split** (`BATCH_MODE=split`, the default) into one request per point. To avoid hammering your own server with a burst of requests, the split is **serial by default** (one request at a time, in chronological order). Tune it with:
+
+  | Variable                     | Default  | Description                                                          |
+  | ---------------------------- | -------- | -------------------------------------------------------------------- |
+  | `TARGET_n_BATCH_MODE`        | `split`  | `split` (one request per point) or `latest` (newest point only)      |
+  | `SPLIT_CONCURRENCY`          | `1`      | Global default for max in-flight requests per target while splitting |
+  | `SPLIT_DELAY_MS`             | `0`      | Global default delay between requests per target while splitting     |
+  | `TARGET_n_SPLIT_CONCURRENCY` | (global) | Per-target override of `SPLIT_CONCURRENCY`                           |
+  | `TARGET_n_SPLIT_DELAY_MS`    | (global) | Per-target override of `SPLIT_DELAY_MS`                              |
+
+  Example — feed Dawarich the raw batch for full history, give Home Assistant just the latest fix, and trickle into a self-hosted Traccar at most 2 at a time with a 200 ms gap:
+
+  ```env
+  TARGET_1_URL=https://dawarich.example.com/api/v1/overland/batches?api_key=your-key
+  TARGET_1_TYPE=overland
+
+  TARGET_2_URL=http://homeassistant:8123/api/webhook/your-webhook-id
+  TARGET_2_TYPE=colota
+  TARGET_2_BATCH_MODE=latest
+
+  TARGET_3_URL=https://traccar.example.com:5055
+  TARGET_3_TYPE=traccar
+  TARGET_3_SPLIT_CONCURRENCY=2
+  TARGET_3_SPLIT_DELAY_MS=200
+  ```
 
 ## Environment variables
 
@@ -159,14 +196,19 @@ TARGET_6_TYPE=owntracks
 | `PORT` | `3000` | Port to listen on |
 | `API_KEY` | - | If set, requests must include it via `x-api-key` header, `?api_key=` query param, or `Authorization: Bearer` |
 | `FORWARD_TIMEOUT_MS` | `30000` | Per-target HTTP timeout in milliseconds |
+| `SPLIT_CONCURRENCY` | `1` | Default max in-flight requests per target when splitting a batch (non-`overland` targets) |
+| `SPLIT_DELAY_MS` | `0` | Default delay between requests per target when splitting a batch |
 | `TARGET_n_URL` | - | Forward destination (n = 1-20, must be consecutive) |
-| `TARGET_n_TYPE` | `raw` | `owntracks`, `geopulse`, `traccar`, `colota`, or `raw` |
+| `TARGET_n_TYPE` | `raw` | `owntracks`, `geopulse`, `traccar`, `colota`, `overland`, or `raw` |
 | `TARGET_n_METHOD` | auto | `GET` or `POST` - overrides the default method for the target type |
 | `TARGET_n_AUTH` | - | Full `Authorization` header value (e.g. `Bearer your-token`) |
 | `TARGET_n_TID` | `CL` (owntracks) / `colota` (traccar) | Tracker ID for `owntracks` targets / device ID for `traccar` targets |
 | `TARGET_n_USER` | `colota` | `X-Limit-U` header for `owntracks` targets |
 | `TARGET_n_DEVICE` | `phone` | `X-Limit-D` fallback for `owntracks` targets - overridden by the payload's `tid` field when present |
 | `TARGET_n_FILTER_TID` | - | Only forward to this target when payload `tid` matches this value |
+| `TARGET_n_BATCH_MODE` | `split` | How a batch upload is handled: `split` (one request per point) or `latest` (newest point only) |
+| `TARGET_n_SPLIT_CONCURRENCY` | (global) | Per-target override of `SPLIT_CONCURRENCY` |
+| `TARGET_n_SPLIT_DELAY_MS` | (global) | Per-target override of `SPLIT_DELAY_MS` |
 
 ## Multi-user / TID routing
 

--- a/src/forwarder.ts
+++ b/src/forwarder.ts
@@ -3,47 +3,102 @@ import { transformPayload, type ColotaPayload } from "./transform"
 import { maskUrl } from "./utils"
 
 const FORWARD_TIMEOUT = Number(process.env.FORWARD_TIMEOUT_MS) || 30_000
+const DEFAULT_SPLIT_CONCURRENCY = Number(process.env.SPLIT_CONCURRENCY) || 1
+const DEFAULT_SPLIT_DELAY_MS = Number(process.env.SPLIT_DELAY_MS) || 0
+
+export interface OverlandEnvelope {
+  locations: unknown[]
+  device_id?: string
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function dispatch(target: Target, url: string, init: RequestInit): Promise<void> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), FORWARD_TIMEOUT)
+  try {
+    const res = await fetch(url, { ...init, signal: controller.signal })
+    if (!res.ok) {
+      const text = (await res.text()).slice(0, 200)
+      console.warn(`[forwarder] ${maskUrl(target.url)} responded ${res.status}: ${text}`)
+    }
+  } catch (err) {
+    console.error(`[forwarder] Failed to reach ${maskUrl(target.url)}:`, err)
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+/** Sends one transformed point to a target. */
+async function sendToTarget(target: Target, payload: ColotaPayload): Promise<void> {
+  const defaultGet = target.type === "traccar"
+  const isGet = target.method ? target.method === "GET" : defaultGet
+  const transformed = transformPayload(payload, target)
+  const headers: Record<string, string> = {}
+  if (!isGet) headers["Content-Type"] = "application/json"
+  if (target.auth) headers["Authorization"] = target.auth
+  if (target.type === "owntracks") {
+    headers["X-Limit-U"] = target.user ?? "colota"
+    headers["X-Limit-D"] = payload.tid ?? target.device ?? "phone"
+  }
+
+  let url = target.url
+  if (isGet) {
+    const params = new URLSearchParams(Object.entries(transformed).map(([k, v]) => [k, String(v)]))
+    url = `${target.url}?${params}`
+  }
+
+  await dispatch(target, url, {
+    method: isGet ? "GET" : "POST",
+    headers,
+    ...(isGet ? {} : { body: JSON.stringify(transformed) })
+  })
+}
+
+/** POSTs the raw batch to an `overland` target. */
+async function sendEnvelopeToTarget(target: Target, envelope: OverlandEnvelope): Promise<void> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" }
+  if (target.auth) headers["Authorization"] = target.auth
+  await dispatch(target, target.url, { method: "POST", headers, body: JSON.stringify(envelope) })
+}
+
+/** Sends a batch as single requests to one target, capped by concurrency + delay. */
+async function splitToTarget(target: Target, payloads: ColotaPayload[]): Promise<void> {
+  const concurrency = Math.max(1, target.splitConcurrency ?? DEFAULT_SPLIT_CONCURRENCY)
+  const delayMs = Math.max(0, target.splitDelayMs ?? DEFAULT_SPLIT_DELAY_MS)
+
+  let index = 0
+  const worker = async (): Promise<void> => {
+    while (index < payloads.length) {
+      const payload = payloads[index++]
+      await sendToTarget(target, payload)
+      if (delayMs > 0 && index < payloads.length) await sleep(delayMs)
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(concurrency, payloads.length) }, worker)
+  await Promise.all(workers)
+}
 
 export async function forwardToAll(targets: Target[], payload: ColotaPayload): Promise<void> {
   const filtered = targets.filter((t) => !t.filter_tid || payload.tid === t.filter_tid)
+  await Promise.allSettled(filtered.map((target) => sendToTarget(target, payload)))
+}
+
+/** Fans an Overland batch out by target: */
+export async function forwardBatch(
+  targets: Target[],
+  envelope: OverlandEnvelope,
+  payloads: ColotaPayload[]
+): Promise<void> {
+  const deviceId = envelope.device_id
+  const matching = targets.filter((t) => !t.filter_tid || deviceId === t.filter_tid)
+  const latest = payloads.length > 0 ? payloads.reduce((a, b) => (b.tst > a.tst ? b : a)) : undefined
   await Promise.allSettled(
-    filtered.map(async (target) => {
-      const controller = new AbortController()
-      const timeout = setTimeout(() => controller.abort(), FORWARD_TIMEOUT)
-      try {
-        const defaultGet = target.type === "traccar"
-        const isGet = target.method ? target.method === "GET" : defaultGet
-        const transformed = transformPayload(payload, target)
-        const headers: Record<string, string> = {}
-        if (!isGet) headers["Content-Type"] = "application/json"
-        if (target.auth) headers["Authorization"] = target.auth
-        if (target.type === "owntracks") {
-          headers["X-Limit-U"] = target.user ?? "colota"
-          headers["X-Limit-D"] = payload.tid ?? target.device ?? "phone"
-        }
-
-        let url = target.url
-        if (isGet) {
-          const params = new URLSearchParams(Object.entries(transformed).map(([k, v]) => [k, String(v)]))
-          url = `${target.url}?${params}`
-        }
-
-        const res = await fetch(url, {
-          method: isGet ? "GET" : "POST",
-          headers,
-          ...(isGet ? {} : { body: JSON.stringify(transformed) }),
-          signal: controller.signal
-        })
-
-        if (!res.ok) {
-          const text = (await res.text()).slice(0, 200)
-          console.warn(`[forwarder] ${maskUrl(target.url)} responded ${res.status}: ${text}`)
-        }
-      } catch (err) {
-        console.error(`[forwarder] Failed to reach ${maskUrl(target.url)}:`, err)
-      } finally {
-        clearTimeout(timeout)
-      }
+    matching.map((target) => {
+      if (target.type === "overland") return sendEnvelopeToTarget(target, envelope)
+      if (target.batchMode === "latest") return latest ? sendToTarget(target, latest) : Promise.resolve()
+      return splitToTarget(target, payloads)
     })
   )
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,10 +1,10 @@
+import "dotenv/config" // must load .env before any module reads process.env at import time
 import express, { Request, Response, NextFunction, Application } from "express"
 import crypto from "crypto"
 import { loadTargets } from "./targets"
-import { forwardToAll } from "./forwarder"
-import { owntracksToColota, type ColotaPayload } from "./transform"
-import { maskUrl } from "./utils"
-import "dotenv/config"
+import { forwardToAll, forwardBatch } from "./forwarder"
+import { owntracksToColota, overlandFeatureToColota, type ColotaPayload } from "./transform"
+import { maskUrl, hasFiniteNumbers } from "./utils"
 
 const app: Application = express()
 const PORT = Number(process.env.PORT) || 3000
@@ -70,17 +70,7 @@ app.post("/owntracks", authenticate, async (req: Request, res: Response): Promis
     return
   }
 
-  const { lat, lon, tst, acc } = body
-  if (
-    typeof lat !== "number" ||
-    !isFinite(lat) ||
-    typeof lon !== "number" ||
-    !isFinite(lon) ||
-    typeof tst !== "number" ||
-    !isFinite(tst) ||
-    typeof acc !== "number" ||
-    !isFinite(acc)
-  ) {
+  if (!hasFiniteNumbers(body, ["lat", "lon", "tst", "acc"])) {
     res.status(400).json({ error: "Missing or invalid required fields: lat, lon, tst, acc" })
     return
   }
@@ -103,20 +93,7 @@ app.post("/locations", authenticate, async (req: Request, res: Response): Promis
   }
 
   const body = req.body as Record<string, unknown>
-  if (
-    typeof body.lat !== "number" ||
-    !isFinite(body.lat) ||
-    typeof body.lon !== "number" ||
-    !isFinite(body.lon) ||
-    typeof body.tst !== "number" ||
-    !isFinite(body.tst) ||
-    typeof body.acc !== "number" ||
-    !isFinite(body.acc) ||
-    typeof body.batt !== "number" ||
-    !isFinite(body.batt) ||
-    typeof body.bs !== "number" ||
-    !isFinite(body.bs)
-  ) {
+  if (!hasFiniteNumbers(body, ["lat", "lon", "tst", "acc", "batt", "bs"])) {
     res.status(400).json({ error: "Missing or invalid required fields: lat, lon, tst, acc, batt, bs" })
     return
   }
@@ -129,16 +106,55 @@ app.post("/locations", authenticate, async (req: Request, res: Response): Promis
   const payload = body as unknown as ColotaPayload
   const forwarded = targets.filter((t) => !t.filter_tid || payload.tid === t.filter_tid).length
 
-  // Fire-and-forget: respond immediately, forward in background
   res.status(200).json({ message: "Accepted", forwarded })
   forwardToAll(targets, payload)
 })
 
+app.post("/overland", authenticate, async (req: Request, res: Response): Promise<void> => {
+  if (!req.is("application/json")) {
+    res.status(400).json({ error: "Invalid content type" })
+    return
+  }
+
+  const body = req.body as { locations?: unknown; device_id?: unknown }
+  if (!Array.isArray(body.locations)) {
+    res.status(400).json({ error: "Missing or invalid 'locations' array" })
+    return
+  }
+
+  const deviceId = typeof body.device_id === "string" ? body.device_id : undefined
+
+  // 201 per Overland spec; fire-and-forget so the client doesn't wait on N target round-trips.
+  res.status(201).json({ result: "ok" })
+
+  if (targets.length === 0) return
+
+  const payloads: ColotaPayload[] = []
+  let skipped = 0
+  for (const feature of body.locations) {
+    try {
+      payloads.push(overlandFeatureToColota(feature, deviceId))
+    } catch (err) {
+      skipped++
+      console.warn(`[overland] Skipped malformed Feature: ${(err as Error).message}`)
+    }
+  }
+  if (skipped > 0) {
+    console.warn(`[overland] ${skipped}/${body.locations.length} Features skipped`)
+  }
+
+  forwardBatch(targets, { locations: body.locations, device_id: deviceId }, payloads)
+})
+
 app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
+  // Respect upstream status (express.json sets 400 on bad JSON).
+  const status =
+    (err as { status?: number; statusCode?: number }).status ?? (err as { statusCode?: number }).statusCode ?? 500
   const errUrl = new URL(req.originalUrl, "http://localhost")
   errUrl.searchParams.delete("api_key")
-  console.error(`[ERROR] ${req.method} ${errUrl.pathname}${errUrl.search}:`, err)
-  res.status(500).json({ error: "Internal Server Error" })
+  if (status >= 500) console.error(`[ERROR] ${req.method} ${errUrl.pathname}${errUrl.search}:`, err)
+  else console.warn(`[${status}] ${req.method} ${errUrl.pathname}${errUrl.search}: ${err.message}`)
+  res.status(status).json({ error: status >= 500 ? "Internal Server Error" : "Bad Request" })
 })
 
 app.listen(PORT, () => {

--- a/src/targets.ts
+++ b/src/targets.ts
@@ -1,6 +1,6 @@
-export type TargetType = "owntracks" | "geopulse" | "traccar" | "colota" | "raw"
+export type TargetType = "owntracks" | "geopulse" | "traccar" | "colota" | "overland" | "raw"
 
-const VALID_TYPES: TargetType[] = ["owntracks", "geopulse", "traccar", "colota", "raw"]
+const VALID_TYPES: TargetType[] = ["owntracks", "geopulse", "traccar", "colota", "overland", "raw"]
 
 export interface Target {
   url: string
@@ -11,6 +11,9 @@ export interface Target {
   user?: string // X-Limit-U header for owntracks type (default: "colota")
   device?: string // X-Limit-D header for owntracks type (default: "phone")
   filter_tid?: string // only forward to this target when payload tid matches
+  batchMode?: "split" | "latest" // how a batch is handled: split into single points (default) or newest point only
+  splitConcurrency?: number // max in-flight requests when splitting a batch (non-overland targets)
+  splitDelayMs?: number // delay between requests when splitting a batch (non-overland targets)
 }
 
 export function loadTargets(): Target[] {
@@ -39,6 +42,13 @@ export function loadTargets(): Target[] {
     const user = process.env[`TARGET_${i}_USER`]
     const device = process.env[`TARGET_${i}_DEVICE`]
     const filter_tid = process.env[`TARGET_${i}_FILTER_TID`]
+    const rawBatchMode = process.env[`TARGET_${i}_BATCH_MODE`]?.toLowerCase()
+    if (rawBatchMode && rawBatchMode !== "split" && rawBatchMode !== "latest") {
+      console.warn(`TARGET_${i}_BATCH_MODE "${rawBatchMode}" is invalid, falling back to "split"`)
+    }
+    const batchMode = rawBatchMode === "latest" ? "latest" : undefined
+    const splitConcurrency = Number(process.env[`TARGET_${i}_SPLIT_CONCURRENCY`]) || undefined
+    const splitDelayMs = Number(process.env[`TARGET_${i}_SPLIT_DELAY_MS`]) || undefined
     targets.push({
       url,
       type,
@@ -47,7 +57,10 @@ export function loadTargets(): Target[] {
       ...(tid ? { tid } : {}),
       ...(user ? { user } : {}),
       ...(device ? { device } : {}),
-      ...(filter_tid ? { filter_tid } : {})
+      ...(filter_tid ? { filter_tid } : {}),
+      ...(batchMode ? { batchMode } : {}),
+      ...(splitConcurrency ? { splitConcurrency } : {}),
+      ...(splitDelayMs ? { splitDelayMs } : {})
     })
   }
   return targets

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -27,6 +27,56 @@ export function owntracksToColota(body: Record<string, unknown>): ColotaPayload 
   }
 }
 
+const OVERLAND_BATTERY_STATE_TO_BS: Record<string, number> = {
+  unknown: 0,
+  unplugged: 1,
+  charging: 2,
+  full: 3
+}
+
+/** Throws on bad input so the caller can skip one row without failing the batch. */
+export function overlandFeatureToColota(feature: unknown, deviceId: string | undefined): ColotaPayload {
+  if (typeof feature !== "object" || feature === null) {
+    throw new Error("Feature is not an object")
+  }
+  const f = feature as Record<string, unknown>
+  const geometry = f.geometry as Record<string, unknown> | undefined
+  const coords = geometry?.coordinates as unknown[] | undefined
+  if (!Array.isArray(coords) || coords.length < 2) {
+    throw new Error("Feature has no coordinates")
+  }
+  const lon = coords[0]
+  const lat = coords[1]
+  if (typeof lon !== "number" || !isFinite(lon) || typeof lat !== "number" || !isFinite(lat)) {
+    throw new Error("Coordinates are not numbers")
+  }
+
+  const props = (f.properties as Record<string, unknown>) ?? {}
+  const isoTs = props.timestamp
+  const tst = typeof isoTs === "string" ? Math.floor(Date.parse(isoTs) / 1000) : Math.floor(Date.now() / 1000)
+  if (!isFinite(tst) || tst <= 0) {
+    throw new Error("Invalid timestamp")
+  }
+
+  const acc = typeof props.horizontal_accuracy === "number" ? props.horizontal_accuracy : 0
+  // Overland battery_level is 0-1, ColotaPayload.batt is 0-100.
+  const batt = typeof props.battery_level === "number" ? Math.round(props.battery_level * 100) : 0
+  const bs = typeof props.battery_state === "string" ? (OVERLAND_BATTERY_STATE_TO_BS[props.battery_state] ?? 0) : 0
+
+  return {
+    lat,
+    lon,
+    acc,
+    batt,
+    bs,
+    tst,
+    ...(typeof props.altitude === "number" && { alt: props.altitude }),
+    ...(typeof props.speed === "number" && { vel: props.speed }),
+    ...(typeof props.course === "number" && { bear: props.course }),
+    ...(deviceId && { tid: deviceId })
+  }
+}
+
 export function transformPayload(payload: ColotaPayload, target: Target): Record<string, unknown> {
   switch (target.type) {
     case "owntracks":

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,11 @@
+export function isFiniteNumber(v: unknown): v is number {
+  return typeof v === "number" && isFinite(v)
+}
+
+export function hasFiniteNumbers(obj: Record<string, unknown>, keys: string[]): boolean {
+  return keys.every((k) => isFiniteNumber(obj[k]))
+}
+
 const SENSITIVE_PARAMS = new Set(["api_key", "token"])
 
 export function maskUrl(url: string): string {


### PR DESCRIPTION
feat: fan out Overland batches per target type

overland targets get the whole batch in a single POST. Set BATCH_MODE=latest to forward only the newest point - what you want for Home Assistant and other "current location" sinks. Everything else gets one request per point, throttled so a large batch doesn't flood the target.

Closes #16
