### PR TITLE
fix: preserve tid from OwnTracks payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ TARGET_3_TYPE=owntracks
 
 Targets without `FILTER_TID` receive data from all phones. Targets with `FILTER_TID` only receive data when the payload's `tid` matches.
 
+**Using the OwnTracks app instead of Colota?** The `tid` from OwnTracks `/owntracks` payloads is preserved and routed the same way — but the OwnTracks app limits its Tracker ID (Preferences → Identification) to **2 characters**, so set both the app's TID and `FILTER_TID` to the same short code (e.g. `p1`). The free-form names above (`phone1`, `alice`) only work with the Colota app's custom `tid` field.
+
 ## Security
 
 - Set a strong, random `API_KEY` in your `.env` before going public

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -23,7 +23,8 @@ export function owntracksToColota(body: Record<string, unknown>): ColotaPayload 
     tst: body.tst as number,
     ...(body.alt !== undefined && { alt: body.alt as number }),
     ...(body.vel !== undefined && { vel: body.vel as number }),
-    ...(body.cog !== undefined && { bear: body.cog as number })
+    ...(body.cog !== undefined && { bear: body.cog as number }),
+    ...(typeof body.tid === "string" && { tid: body.tid })
   }
 }
 

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -11,6 +11,16 @@ test("owntracksToColota maps cog->bear and defaults batt/bs", () => {
   assert.equal(r.bs, 0)
 })
 
+test("owntracksToColota preserves tid so FILTER_TID routing and HA naming work", () => {
+  const r = owntracksToColota({ lat: 1, lon: 2, acc: 5, tst: 100, tid: "ab" })
+  assert.equal(r.tid, "ab")
+})
+
+test("owntracksToColota omits tid when absent or non-string", () => {
+  assert.equal("tid" in owntracksToColota({ lat: 1, lon: 2, acc: 5, tst: 100 }), false)
+  assert.equal("tid" in owntracksToColota({ lat: 1, lon: 2, acc: 5, tst: 100, tid: 123 }), false)
+})
+
 test("overlandFeatureToColota parses a valid Feature", () => {
   const r = overlandFeatureToColota(
     {


### PR DESCRIPTION
owntracksToColota dropped the tid field, so FILTER_TID routing never matched (Dawarich filtered out) and Home Assistant fell back to the default "colota" device name. Preserve tid, guarded to string so a non-string value can't leak into routing or the X-Limit-D header.

Fixes #20